### PR TITLE
Added mergeCasts

### DIFF
--- a/src/Traits/HasSnowflakes.php
+++ b/src/Traits/HasSnowflakes.php
@@ -19,4 +19,15 @@ trait HasSnowflakes
     {
         return false;
     }
+    
+    public function mergeCasts($casts)
+    {
+        $casts = $this->casts;
+
+        if (!isset($casts['id'])) {
+            $this->casts = array_merge($casts, [
+                'id' => 'string',
+            ]);
+        }
+    }
 }


### PR DESCRIPTION
This update will automatically cast the id of the model as a string unless specified otherwise. 

This is because there are problems with integer-based IDs that are larger than JavaScript's maximum "safe" integer value.